### PR TITLE
Rename files -> glob

### DIFF
--- a/default/templates/nwOptions.ejs
+++ b/default/templates/nwOptions.ejs
@@ -2,7 +2,7 @@ var nwOptions = {
   buildDir: "./build",
   version: "<%= version %>",
   platforms: <%- JSON.stringify(platforms) %>,
-  files: [
+  glob: [
     "package.json",
     "production.html",
     "node_modules/steal/steal.production.js"


### PR DESCRIPTION
steal-nw allows you to name the property either `files` or `glob`. Since
the steal-cordova lib uses `glob` going to change this to `glob` as
well, for consistency.
