### PR TITLE
Prompt for the serviceBaseURL

### DIFF
--- a/default/index.js
+++ b/default/index.js
@@ -25,6 +25,11 @@ module.exports = generator.Base.extend({
       default : 'latest'
     }, {
       type    : 'input',
+      name    : 'baseURL',
+      message : 'The URL of the service layer',
+      default : undefined
+    }, {
+      type    : 'input',
       name    : 'width',
       message : 'Width of application window',
       default: 1000
@@ -38,9 +43,6 @@ module.exports = generator.Base.extend({
       name: 'platforms',
       message: 'What platforms would you like to support',
       choices: [{
-        name: 'osx32',
-        checked: is.macos
-      }, {
         name: 'osx64',
         checked: is.macos
       }, {
@@ -62,6 +64,7 @@ module.exports = generator.Base.extend({
       this.config.set('height', answers.height);
       this.config.set('platforms', answers.platforms);
       this.config.set('version', answers.version);
+      this.config.set('baseURL', answers.baseURL);
       done();
     }.bind(this));
   },
@@ -126,6 +129,15 @@ module.exports = generator.Base.extend({
         height: this.config.get('height'),
         toolbar: false
       });
+
+      if(this.config.get('baseURL') && json.steal) {
+        json.steal.envs = json.steal.envs || {};
+        var nwEnv = json.steal.envs['nw-production'];
+        if(!nwEnv) {
+          nwEnv = json.steal.envs['nw-production'] = {};
+        }
+        nwEnv.serviceBaseURL = this.config.get('baseURL');
+      }
       fs.writeFile(packageJson, JSON.stringify(json), function() {
         packageJsonDeferred.resolve();
       });

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,7 @@ describe('donejs-nw', function() {
           width: '800',
           height: '600',
           version: '0.0.0',
+          baseURL: 'https://foo.com',
           platforms: ['x']
         })
         .on('end', done);
@@ -93,6 +94,7 @@ describe('donejs-nw', function() {
       assert.file(['package.json']);
       assert.JSONFileContent('package.json', { main: 'app.html' });
       assert.JSONFileContent('package.json', { window: { width: 800, height: 600, toolbar: false } });
+      assert.JSONFileContent('package.json', { steal: { envs: { 'nw-production': {'serviceBaseURL': 'https://foo.com'}}}});
     });
   });
 });

--- a/test/templates/package-json/package.json
+++ b/test/templates/package-json/package.json
@@ -20,7 +20,7 @@
     "src"
   ],
   "keywords": [],
-  "system": {
+  "steal": {
     "main": "donejs-project/index.stache!done-autorender",
     "directories": {
       "lib": "src"


### PR DESCRIPTION
This adds a prompt for the serviceBaseURL which is used in the models in
order to connect to an external service. This configuration is saved in
the package.json under the steal.envs.

Closes #4 and #5