### PR TITLE
Remove steal.production.js

### DIFF
--- a/default/templates/nwOptions.ejs
+++ b/default/templates/nwOptions.ejs
@@ -4,8 +4,7 @@ var nwOptions = {
   platforms: <%- JSON.stringify(platforms) %>,
   glob: [
     "package.json",
-    "production.html",
-    "node_modules/steal/steal.production.js"
+    "production.html"
   ]
 };
 


### PR DESCRIPTION
This removes steal.production.js as a bundled asset. In Steal 1.0 this
is handled by steal-tools during the normal build.